### PR TITLE
Fixed signup without signup code

### DIFF
--- a/entry.coffee
+++ b/entry.coffee
@@ -23,7 +23,7 @@ Meteor.startup ->
       showSignupCode: AccountsEntry.settings.signupCode?
 
     entryValidateSignupCode: (signupCode) ->
-      signupCode is AccountsEntry.settings.signupCode
+      not AccountsEntry.settings.showSignupCode or signupCode is AccountsEntry.settings.signupCode
 
     accountsCreateUser: (username, email, password) ->
       if username


### PR DESCRIPTION
Please pull this simple fix in the sign up functionality. 

In the current version it's impossible to sign up without the signup code. This is because entryValidateSignupCode is called on every signup request, but the function doesn't check whether showSignupCode setting is true, so it always returns false and causes the "Signup code incorrect" error.
