### PR TITLE
use the existing Accounts method call

### DIFF
--- a/client/views/signUp/signUp.coffee
+++ b/client/views/signUp/signUp.coffee
@@ -116,7 +116,7 @@ Template.entrySignUp.events
         newUserData = 
           email: email
           password: password
-          profile: profile: AccountsEntry.settings.defaultProfile || {}
+          profile: AccountsEntry.settings.defaultProfile || {}
         if username
           data.username = username
         Accounts.createUser newUserData, (err, data) ->


### PR DESCRIPTION
I'm using accounts-password and Accounts-entry was not sending verification emails when users signed up.
Calling the existing Accounts.createUser method will handle sending the verification email (if configured in Accounts) when creating a user.
