### PR TITLE
Fix for possible password exploit

### DIFF
--- a/client/views/signIn/signIn.coffee
+++ b/client/views/signIn/signIn.coffee
@@ -26,6 +26,7 @@ Template.entrySignIn.events
     Session.set('password', $('input[name="password"]').val())
 
     Meteor.loginWithPassword(Session.get('email'), Session.get('password'), (error)->
+      Session.set('password', undefined)
       if error
         Session.set('entryError', error.reason)
       else


### PR DESCRIPTION
The password is stored in the session, so in the client console it could easily be return by "getting" the session value for. This could be done by anybody who get's access to the browser.
Workaround: unset the password, cause it is no longer needed
