### PR TITLE
Update language to match default

### DIFF
--- a/client/entry.coffee
+++ b/client/entry.coffee
@@ -8,7 +8,7 @@ AccountsEntry =
   config: (appConfig) ->
     @settings = _.extend(@settings, appConfig)
 
-    i18n.setDefaultLanguage "en_US"
+    i18n.setDefaultLanguage "en"
     if appConfig.language
       i18n.setLanguage appConfig.language
 


### PR DESCRIPTION
`en_US` != `en`

It may be better to reject this fix and change english.coffee, but I'm unsure if you want to use 2-char or 4-char codes. 

Fixes #60

Cheers
