### PR TITLE
Don't go to dashboardRoute until social auth is completed

### DIFF
--- a/client/views/social/social.coffee
+++ b/client/views/social/social.coffee
@@ -29,7 +29,5 @@ Template.entrySocial.events
 
     loginWithService(options, callback)
 
-    Router.go AccountsEntry.settings.dashboardRoute
-
 capitalize = (str) ->
   str.charAt(0).toUpperCase() + str.slice(1)


### PR DESCRIPTION
Removed extra routing to dashboardRoute since it was causing the app to redirect to dashboardRoute before the callback was finished (and therefore before the user had even authenticated! Major security flaw to say the least). The callback already handles routing correctly if there is no error, so there was no need for the extra routing.
