### PR TITLE
Wait until logout has completed before redirecting to homeRoute

### DIFF
--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -22,8 +22,8 @@ Router.map ->
     before: ->
       Session.set('entryError', undefined)
       if AccountsEntry.settings.homeRoute
-        Meteor.logout()
-        Router.go AccountsEntry.settings.homeRoute
+        Meteor.logout () ->
+          Router.go AccountsEntry.settings.homeRoute
       @stop()
 
   @route 'entryResetPassword',


### PR DESCRIPTION
Fixed a bug where routing was happening too fast (before logout was finished processing) resulting with Router evaluating the homeRoute as if the user was still logged in.

Now the redirect to homeRoute only happens once logout() is finished processing.
