### PR TITLE
Correcting error #130 - changing @stop to pause()

### DIFF
--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -24,7 +24,7 @@ Router.map ->
       if AccountsEntry.settings.homeRoute
         Meteor.logout () ->
           Router.go AccountsEntry.settings.homeRoute
-      @stop()
+      @pause()
 
   @route 'entryResetPassword',
     path: 'reset-password/:resetToken'


### PR DESCRIPTION
This appears to fix issue #130:
https://github.com/Differential/accounts-entry/issues/130

@stop is depreciated in iron-router 0.7.0 and going forward we should use @pause().  When @stop is used in the entrySignOut route, BlazeLayout throws the following error in the console (client side):

Exception from Deps recompute function: Error: BlazeLayout: Sorry, couldn't find a template named entrySignOut. Are you sure you defined it?

Replacing @stop with @pause seems to fix the issue.
