### PR TITLE
Added option to override all templates.

### DIFF
--- a/client/entry.coffee
+++ b/client/entry.coffee
@@ -19,9 +19,10 @@ AccountsEntry =
     if appConfig.language
       T9n.language = appConfig.language
 
-    if appConfig.signUpTemplate
-      signUpRoute = Router.routes['entrySignUp']
-      signUpRoute.options.template = appConfig.signUpTemplate
+    templates = appConfig.templates
+    if templates?
+      for name, template of templates
+        Router.routes[name]?.options.template = template
 
   signInRequired: (router, extraCondition) ->
     extraCondition ?= true


### PR DESCRIPTION
Pass the options like so:

```
Meteor.startup(function() {
  AccountsEntry.config({
    templates: {
      entrySignIn: 'signIn'
    }
  });
});
```

Where `templates` is a map of the internal template to the user-defined template name.
