### PR TITLE
updating #143 which attempts to correct error #130

### DIFF
--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -59,12 +59,12 @@ Router.map ->
 
   @route 'entrySignOut',
     path: '/sign-out'
-    onBeforeAction: ->
+    onBeforeAction: (pause)->
       Session.set('entryError', undefined)
       if AccountsEntry.settings.homeRoute
         Meteor.logout () ->
           Router.go AccountsEntry.settings.homeRoute
-      @pause()
+      pause()
 
   @route 'entryResetPassword',
     path: 'reset-password/:resetToken'


### PR DESCRIPTION
This issue came up in iron-router:  EventedMind/iron-router#620

This answer (from link above) is to pass pause as a parameter and then call it, like so: 

Router.onBeforeAction(function(pause) {
  // ...
  pause()
});
