### PR TITLE
ExtraSignupFields were not persisting to the profile

### DIFF
--- a/client/views/signUp/signUp.coffee
+++ b/client/views/signUp/signUp.coffee
@@ -75,6 +75,18 @@ AccountsEntry.entrySignUpEvents = {
 
     fields = AccountsEntry.settings.passwordSignupFields
 
+    booleanify = (str)->
+      str = true if str is "true"
+      str = false if str is "false"
+      return str
+
+    extraFields = AccountsEntry.settings.extraSignUpFields
+    extraFieldValues = {}
+    extraFields.forEach (f)->
+      fieldValue = booleanify(t.find("input[name=\""+f.name+"\"]:last").value);
+      extraFieldValues[f.name] = fieldValue
+
+    _.extend(AccountsEntry.settings.defaultProfile, extraFieldValues)
 
     passwordErrors = do (password)->
       errMsg = []


### PR DESCRIPTION
ExtraSignupFields were not persisting to the profile, so I added this me...

CAVEAT: This code runs on the client-side of Meteor, and as such it opened up another question for me. When you declare “defaultProfile” on the Accounts.config on the server side, none of this code reads from that server-side config. Thus we would need to declare the values of defaultProfile in the client-side of the app, which I would think possibly is a security issue.

What I am thinking: The validations need to happen on the client side, but the saving needs to happen on the server, or at least the addition of the defaultProfile needs to happen on the server, and probably it needs not to persist some of those fields to the client side, especially if there is business logic in them (meaning administrative permissions, roles, etc). Perhaps we need to go a step further and declare another object inside the User record that would contain “secret” information.

I welcome your thoughts on this, and will be glad to contribute some more code.
