### PR TITLE
Typo in bootstrap class

### DIFF
--- a/client/views/signUp/extraSignUpFields.html
+++ b/client/views/signUp/extraSignUpFields.html
@@ -6,7 +6,7 @@
 
 <template name="_entryExtraSignUpField">
     {{#if isTextField }}
-    <div class="form_group">
+    <div class="form-group">
         {{text_field field type=type required=required label=label placeholder=placeholder }}
     </div>
     {{/if}}


### PR DESCRIPTION
Bootstrap form group issue... 

form_group >> form-group

corrects spacing for multiple instances of extrasignupfields. 
