### PR TITLE
Add new classes to allow fluid bootstrap containers and rows

### DIFF
--- a/client/entry.coffee
+++ b/client/entry.coffee
@@ -9,6 +9,8 @@ AccountsEntry =
     entrySignUp: '/sign-up'
     extraSignUpFields: []
     showOtherLoginServices: true
+    fluidLayout: false
+    useContainer: true
 
   isStringEmail: (email) ->
     emailPattern = /^([\w.-]+)@([\w.-]+)\.([a-zA-Z.]{2,6})$/i

--- a/client/helpers.coffee
+++ b/client/helpers.coffee
@@ -38,3 +38,21 @@ UI.registerHelper 'passwordLoginService', ->
 
 UI.registerHelper 'showCreateAccountLink', ->
   return !Accounts._options.forbidClientAccountCreation
+
+UI.registerHelper 'fluidLayout', ->
+  AccountsEntry.settings.fluidLayout is true
+
+UI.registerHelper 'containerCSSClass', ->
+  if AccountsEntry.settings.useContainer is false
+    "accounts-entry-container"
+  else
+    if AccountsEntry.settings.fluidLayout is true
+      "container-fluid"
+    else
+      "container"
+    
+UI.registerHelper 'rowCSSClass', ->
+  if AccountsEntry.settings.fluidLayout is true
+    "row-fluid"
+  else
+    "row"

--- a/client/views/forgotPassword/forgotPassword.html
+++ b/client/views/forgotPassword/forgotPassword.html
@@ -1,6 +1,6 @@
 <template name='entryForgotPassword'>
-  <div class="container">
-    <div class="row">
+  <div class="{{containerCSSClass}}">
+    <div class="{{rowCSSClass}}">
       {{#if logo}}
         <div class="entry-logo">
             <a href="/"><img src="{{logo}}" alt="logo"></a>

--- a/client/views/resetPassword/resetPassword.html
+++ b/client/views/resetPassword/resetPassword.html
@@ -1,6 +1,6 @@
 <template name='entryResetPassword'>
-  <div class="container">
-    <div class="row">
+  <div class="{{containerCSSClass}}">
+    <div class="{{rowCSSClass}}">
       {{#if logo}}
         <div class="entry-logo">
             <a href="/"><img src="{{logo}}" alt="logo"></a>

--- a/client/views/signIn/signIn.html
+++ b/client/views/signIn/signIn.html
@@ -1,6 +1,6 @@
 <template name='entrySignIn'>
-  <div class="container">
-    <div class="row">
+  <div class="{{containerCSSClass}}">
+    <div class="{{rowCSSClass}}">
       {{#if logo}}
         <div class="entry-logo">
             <a href="/"><img src="{{logo}}" alt="logo"></a>
@@ -28,7 +28,7 @@
         {{#if passwordLoginService}}
           <form class="entry-form" id='signIn'>
             <div class="form-group">
-              <input autofocus name="email" type="{{emailInputType}}" class="form-control" value='{{email}}' placeholder="{{emailPlaceholder}}">
+              <input autofocus name="email" type="{{emailInputType}}" class="form-control" value='{{email}}' placeholder="{{emailPlaceholder}}" autocapitalize="none" autocomplete="off" autocorrect="off">
             </div>
             <div class="form-group">
               <input name="password" type="password" class="form-control" value='{{password}}' placeholder="{{t9n 'password'}}">

--- a/client/views/signUp/signUp.html
+++ b/client/views/signUp/signUp.html
@@ -1,6 +1,6 @@
 <template name='entrySignUp'>
-  <div class="container">
-    <div class="row">
+  <div class="{{containerCSSClass}}">
+    <div class="{{rowCSSClass}}">
       {{#if logo}}
         <div class="entry-logo">
             <a href="/"><img src="{{logo}}" alt="logo"></a>
@@ -32,7 +32,7 @@
             {{#if showUsername}}
               <div class="form-group">
                 <label>{{t9n "username"}}</label>
-                <input autofocus name="username" type="string" class="form-control" value=''>
+                <input autofocus name="username" type="string" class="form-control" value=''  autocapitalize="none" autocomplete="off" autocorrect="off">
               </div>
             {{/if}}
 
@@ -40,9 +40,9 @@
               <div class="form-group">
                 <label>{{t9n "emailAddress"}}</label>
                 {{#if showUsername}}
-                  <input type="email" class="form-control" value='{{emailAddress}}'>
+                  <input type="email" class="form-control" value='{{emailAddress}}'  autocapitalize="none" autocomplete="off" autocorrect="off">
                 {{else}}
-                  <input autofocus type="email" class="form-control" value='{{emailAddress}}'>
+                  <input autofocus type="email" class="form-control" value='{{emailAddress}}'  autocapitalize="none" autocomplete="off" autocorrect="off" >
                 {{/if}}
               </div>
             {{/if}}
@@ -55,7 +55,7 @@
             {{#if showSignupCode}}
               <div class="form-group">
                 <label>{{t9n "signupCode"}}</label>
-                <input name="signupCode" type="string" class="form-control" value=''>
+                <input name="signupCode" type="string" class="form-control" value=''  autocapitalize="none" autocomplete="off" autocorrect="off" >
               </div>
             {{/if}}
 

--- a/tests/client.coffee
+++ b/tests/client.coffee
@@ -1,6 +1,6 @@
 renderToDiv = (comp) ->
   div = document.createElement("DIV")
-  UI.materialize comp, div
+  Blaze.render(comp).attach(div)
   div
 
 Tinytest.add "Accounts Entry - {{accountButtons}} helper", (test) ->


### PR DESCRIPTION
Add new CSS classes to allow fluid bootstrap containers and rows.
Also allow suppression of the CSS class for the container div (for cases where it's already in a container).
New settings and defaults:
    fluidLayout: false
    useContainer: true

Also fix issue with unit tests in tests/client.coffee for Meteor 0.8.3