### PR TITLE
fixed bug in signIn template with login button

### DIFF
--- a/client/views/signIn/signIn.html
+++ b/client/views/signIn/signIn.html
@@ -35,8 +35,8 @@
             </div>
             {{#unless isUsernameOnly}}
               <p><a href="/forgot-password">{{t9n "forgotPassword"}}</a></p>
-              <button type="submit" class="submit btn btn-block btn-default">{{t9n "signIn"}}</button>
             {{/unless}}
+            <button type="submit" class="submit btn btn-block btn-default">{{t9n "signIn"}}</button>
           </form>
         {{/if}}
         {{#if showCreateAccountLink}}


### PR DESCRIPTION
There was a bug that seemingly prevented the signIn button from being shown when using USERNAME_ONLY and accounts-password as a provider.   

Hopefully this line being moved is indeed a proper solution!

![Bug Screenshot](https://cloud.githubusercontent.com/assets/511854/3857829/d36214b8-1f07-11e4-902a-66d53d3478c8.png)
