### PR TITLE
Login Redirection Fix

### DIFF
--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -75,6 +75,12 @@ Router.map ->
       Session.set('entryError', undefined)
       Session.set('resetToken', @params.resetToken)
 
+# Get all the accounts-entry routes one time
+exclusions = [];
+_.each Router.routes, (route)->
+  exclusions.push route.name
 # Change the fromWhere session variable when you leave a path
 Router.onStop ->
-  Session.set('fromWhere', Router.current().path)
+  # If the route is an entry route, no need to save it
+  if (!_.contains(exclusions, Router.current().route.name))
+    Session.set('fromWhere', Router.current().path)


### PR DESCRIPTION
- Fixes Issue #218
- Logic is that it sets the previous path when leaving a route which can then be referenced by the sign-in page
