### PR TITLE
Register with strings not defined

### DIFF
--- a/client/helpers.coffee
+++ b/client/helpers.coffee
@@ -38,3 +38,12 @@ UI.registerHelper 'passwordLoginService', ->
 
 UI.registerHelper 'showCreateAccountLink', ->
   return !Accounts._options.forbidClientAccountCreation
+
+UI.registerHelper 'usernameSignup', ->
+  return (AccountsEntry.settings.passwordSignupFields == "USERNAME_ONLY")
+
+UI.registerHelper 'emailSignup', ->
+  return (AccountsEntry.settings.passwordSignupFields == "EMAIL_ONLY")
+
+UI.registerHelper 'usernameOptEmailSignup', ->
+  return (AccountsEntry.settings.passwordSignupFields == "USERNAME_AND_OPTIONAL_EMAIL")

--- a/client/t9n/arabic.coffee
+++ b/client/t9n/arabic.coffee
@@ -15,6 +15,7 @@ ar =
   email: "البريد الالكترونى"
   ifYouAlreadyHaveAnAccount: "اذا كان عندك حساب"
   signUpWithYourEmailAddress: "سجل ببريدك الالكترونى"
+  signUpWithUsername: "Register with a username"
   username: "اسم المستخدم"
   optional: "اختيارى"
   signupCode: "رمز التسجيل"

--- a/client/t9n/english.coffee
+++ b/client/t9n/english.coffee
@@ -15,6 +15,7 @@ en =
   email: "Email"
   ifYouAlreadyHaveAnAccount: "If you already have an account"
   signUpWithYourEmailAddress: "Register with your email address"
+  signUpWithUsername: "Register with a username"
   username: "Username"
   optional: "Optional"
   signupCode: "Registration Code"

--- a/client/t9n/french.coffee
+++ b/client/t9n/french.coffee
@@ -15,6 +15,7 @@ fr =
   email: "Email"
   ifYouAlreadyHaveAnAccount: "Si vous avez déjà un compte"
   signUpWithYourEmailAddress: "S'enregistrer avec votre adresse email"
+  signUpWithUsername: "Register with a username"
   username: "Nom d'utilisateur"
   optional: "Optionnel"
   signupCode: "Code d'inscription"

--- a/client/t9n/german.coffee
+++ b/client/t9n/german.coffee
@@ -15,6 +15,7 @@ de =
   email: "E-Mail"
   ifYouAlreadyHaveAnAccount: "Falls Sie ein Konto haben, bitte hier"
   signUpWithYourEmailAddress: "Mit E-Mail registrieren"
+  signUpWithUsername: "Register with a username"
   username: "Benutzername"
   optional: "Optional"
   signupCode: "Registrierungscode"

--- a/client/t9n/italian.coffee
+++ b/client/t9n/italian.coffee
@@ -15,6 +15,7 @@ it =
   email: "Email"
   ifYouAlreadyHaveAnAccount: "Se hai già un account"
   signUpWithYourEmailAddress: "Registrati con il tuo indirizzo email"
+  signUpWithUsername: "Register with a username"
   username: "Username"
   optional: "Opzionale"
   signupCode: "Codice di Registrazione"

--- a/client/t9n/polish.coffee
+++ b/client/t9n/polish.coffee
@@ -15,6 +15,7 @@ pl =
   email: "Email"
   ifYouAlreadyHaveAnAccount: "Jeżeli już masz konto"
   signUpWithYourEmailAddress: "Zarejestruj się używając adresu email"
+  signUpWithUsername: "Register with a username"
   username: "Nazwa użytkownika"
   optional: "Nieobowiązkowe"
   signupCode: "Kod rejestracji"

--- a/client/t9n/portuguese.coffee
+++ b/client/t9n/portuguese.coffee
@@ -15,6 +15,7 @@ pt =
   email: "E-mail"
   ifYouAlreadyHaveAnAccount: "Se você já tem uma conta"
   signUpWithYourEmailAddress: "Entre usando seu endereço de e-mail"
+  signUpWithUsername: "Register with a username"
   username: "Nome de usuário"
   optional: "Opcional"
   signupCode: "Código de acesso"

--- a/client/t9n/russian.coffee
+++ b/client/t9n/russian.coffee
@@ -15,6 +15,7 @@ ru =
   email: "Email"
   ifYouAlreadyHaveAnAccount: "Если у вас уже есть аккаунт"
   signUpWithYourEmailAddress: "Зарегистрируйтесь с вашим email адресом"
+  signUpWithUsername: "Register with a username"
   username: "Имя пользователя"
   optional: "Необязательно"
   signupCode: "Регистрационный код"

--- a/client/t9n/slovene.coffee
+++ b/client/t9n/slovene.coffee
@@ -15,6 +15,7 @@ sl =
   email: "Email"
   ifYouAlreadyHaveAnAccount: "Če si že registriran(a),"
   signUpWithYourEmailAddress: "Prijava z email naslovom"
+  signUpWithUsername: "Register with a username"
   username: "Uporabniško ime"
   optional: "Po želji"
   signupCode: "Prijavna koda"

--- a/client/t9n/spanish.coffee
+++ b/client/t9n/spanish.coffee
@@ -14,6 +14,7 @@ es =
   email: "Email"
   ifYouAlreadyHaveAnAccount: "Si ya tenés una cuenta"
   signUpWithYourEmailAddress: "Suscribir con tu email"
+  signUpWithUsername: "Register with a username"
   username: "Usuario"
   optional: "Opcional"
   signupCode: "Codigo para suscribir"

--- a/client/t9n/swedish.coffee
+++ b/client/t9n/swedish.coffee
@@ -15,6 +15,7 @@ sv =
   email: "E-postadress"
   ifYouAlreadyHaveAnAccount: "Om du redan har ett konto"
   signUpWithYourEmailAddress: "Skapa ett konto med din e-postadress"
+  signUpWithUsername: "Register with a username"
   username: "Användarnamn"
   optional: "Valfri"
   signupCode: "Registreringskod"

--- a/client/views/signIn/signIn.html
+++ b/client/views/signIn/signIn.html
@@ -33,10 +33,10 @@
             <div class="form-group">
               <input name="password" type="password" class="form-control" value='{{password}}' placeholder="{{t9n 'password'}}">
             </div>
-            {{#unless isUsernameOnly}}
+            
               <p><a href="{{pathFor 'entryForgotPassword'}}">{{t9n "forgotPassword"}}</a></p>
               <button type="submit" class="submit btn btn-block btn-default">{{t9n "signIn"}}</button>
-            {{/unless}}
+            
           </form>
         {{/if}}
         {{#if showCreateAccountLink}}

--- a/client/views/signUp/signUp.html
+++ b/client/views/signUp/signUp.html
@@ -18,7 +18,15 @@
               <div class="email-option">
                 <strong class="line-thru">{{t9n "OR"}}</strong>
                 <a data-toggle="collapse" href="#signUp">
+                {{#if emailSignup}}
                   {{t9n "signUpWithYourEmailAddress"}}
+                {{/if}}
+                {{#if usernameSignup}}
+                  {{t9n "signUpWithUsername"}}
+                {{/if}}
+                {{#if usernameOptEmailSignup}}
+                  {{t9n "signUpWithUsername"}}
+                {{/if}}
                 </a>
               </div>
             {{/if}}

--- a/server/entry.coffee
+++ b/server/entry.coffee
@@ -18,16 +18,13 @@ Meteor.startup ->
     entryCreateUser: (user) ->
       check user, Object
       profile = AccountsEntry.settings.defaultProfile || {}
+      userProf =
+       password: user.password,
+       profile: _.extend(profile, user.profile)
       if user.username
-        userId = Accounts.createUser
-          username: user.username,
-          email: user.email,
-          password: user.password,
-          profile: _.extend(profile, user.profile)
-      else
-        userId = Accounts.createUser
-          email: user.email
-          password: user.password
-          profile: _.extend(profile, user.profile)
+        userProf['username'] = user.username
+      if user.email
+        userProf['email'] = user.email  
+      userId = Accounts.createUser userProf
       if (user.email && Accounts._options.sendVerificationEmail)
         Accounts.sendVerificationEmail(userId, user.email)

--- a/versions.json
+++ b/versions.json
@@ -86,35 +86,35 @@
     ],
     [
       "iron:controller",
-      "1.0.0"
+      "1.0.3"
     ],
     [
       "iron:core",
-      "1.0.0"
+      "1.0.3"
     ],
     [
       "iron:dynamic-template",
-      "1.0.0"
+      "1.0.3"
     ],
     [
       "iron:layout",
-      "1.0.0"
+      "1.0.3"
     ],
     [
       "iron:location",
-      "1.0.0"
+      "1.0.3"
     ],
     [
       "iron:middleware-stack",
-      "1.0.0"
+      "1.0.3"
     ],
     [
       "iron:router",
-      "1.0.0"
+      "1.0.3"
     ],
     [
       "iron:url",
-      "1.0.0"
+      "1.0.3"
     ],
     [
       "joshowens:simple-form",


### PR DESCRIPTION
On the `sign-up` route, the no matter what you set `passwordSignupFields` to, the text says "Register with Email."

This pr adds in a couple of helpers to correctly determine which text to display with `passwordSignupFields`.

T9n is incomplete.
