### PR TITLE
Customization to reset & forgot password templates added

### DIFF
--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -64,7 +64,27 @@ Router.map ->
     onBeforeAction: ->
       Session.set('entryError', undefined)
       @next()
+    onRun: ->
+      if AccountsEntry.settings.forgotPasswordTemplate
+        @template = AccountsEntry.settings.forgotPasswordTemplate
 
+        # If the user has a custom template, and not using the helper, then
+        # maintain the package Javascript so that OpenGraph tags and share
+        # buttons still work.
+        pkgRendered= Template.entryForgotPassword.rendered
+        userRendered = Template[@template].rendered
+
+        if userRendered
+          Template[@template].rendered = ->
+            pkgRendered.call(@)
+            userRendered.call(@)
+        else
+          Template[@template].rendered = pkgRendered
+
+        Template[@template].events(AccountsEntry.entryForgotPasswordEvents)
+        Template[@template].helpers(AccountsEntry.entryForgotPasswordHelpers)
+      @next()
+      
   @route 'entrySignOut',
     path: '/sign-out'
     onBeforeAction: ()->
@@ -79,6 +99,26 @@ Router.map ->
     onBeforeAction: ->
       Session.set('entryError', undefined)
       Session.set('resetToken', @params.resetToken)
+      @next()
+    onRun: ->
+      if AccountsEntry.settings.resetPasswordTemplate
+        @template = AccountsEntry.settings.resetPasswordTemplate
+
+        # If the user has a custom template, and not using the helper, then
+        # maintain the package Javascript so that OpenGraph tags and share
+        # buttons still work.
+        pkgRendered= Template.entryResetPassword.rendered
+        userRendered = Template[@template].rendered
+
+        if userRendered
+          Template[@template].rendered = ->
+            pkgRendered.call(@)
+            userRendered.call(@)
+        else
+          Template[@template].rendered = pkgRendered
+
+        Template[@template].events(AccountsEntry.entryResetPasswordEvents)
+        Template[@template].helpers(AccountsEntry.entryResetPasswordHelpers)
       @next()
 
 # Get all the accounts-entry routes one time


### PR DESCRIPTION
Use the same way to customize forgot & reset password templates as is is possible for sign in/up templates:

Client or shared code (my model.js):

```
Meteor.startup(function () {
    // code to run on server at startup                                                                                                                                                   
    AccountsEntry.config({
        signUpTemplate: 'my-sign-up',
        signInTemplate: 'my-sign-in',
        forgotPasswordTemplate: 'my-forgot-password',
        resetPasswordTemplate: 'my-reset-password'
    });
});
```

My forgot-password.html:

```
<template name="my-forgot-password">
  <div class="wrapper">
    {{> header}}
    <section>
      {{> entryForgotPassword}}
    </section>
  </div><!--//wrapper-->
  {{> footer}}
</template>
```
