### PR TITLE
Use input name to avoid collisions.

### DIFF
--- a/client/views/resetPassword/resetPassword.coffee
+++ b/client/views/resetPassword/resetPassword.coffee
@@ -8,7 +8,7 @@ Template.entryResetPassword.events
 
   'submit #resetPassword': (event) ->
     event.preventDefault()
-    password = $('input[type="password"]').val()
+    password =  $('input[type="password"][name="new-password"]').val()
 
     passwordErrors = do (password)->
       errMsg = []


### PR DESCRIPTION
If there were multiple, even possibly hidden password input boxes on the page(i.e. accounts-ui dropdowns), it would cause the password reset error mechanism to trigger all errors.
