### PR TITLE
Added minLength requireDigits requireAlpha settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Since this is a young package, we are maintaining compatibility with accounts-ui
         type: "text",                            // The type of field you want
         required: true                           // Adds html 5 required property if true
        }]
+      requireDigits = true,             // true by default, set to false if digits not required in password
+      requireAlpha  = true,             // true by default, set to false if alpha not required in password
+      minLength     = 7                 // 7 characters by default, set to whatever is required
     });
   });
 ```

--- a/client/views/signUp/signUp.coffee
+++ b/client/views/signUp/signUp.coffee
@@ -86,11 +86,12 @@ AccountsEntry.entrySignUpEvents = {
     passwordErrors = do (password)->
       errMsg = []
       msg = false
-      if password.length < 7
+      minLength = if AccountsEntry.settings.minLength? then AccountsEntry.settings.minLength else 7
+      if password.length < minLength
         errMsg.push t9n("error.minChar")
       if password.search(/[a-z]/i) < 0
-        errMsg.push t9n("error.pwOneLetter")
-      if password.search(/[0-9]/) < 0
+        errMsg.push t9n("error.pwOneLetter") and AccountsEntry.settings.requireAlpha?
+      if password.search(/[0-9]/) < 0 and AccountsEntry.settings.requireDigits?
         errMsg.push t9n("error.pwOneDigit")
 
       if errMsg.length > 0


### PR DESCRIPTION
Not everyone has requirements for passwords to include digits or to be a certain length. Added config options to turn these guards off.
