### PR TITLE
Feature/wait for email verification

### DIFF
--- a/client/entry.coffee
+++ b/client/entry.coffee
@@ -9,6 +9,8 @@ AccountsEntry =
     entrySignUp: '/sign-up'
     extraSignUpFields: []
     showOtherLoginServices: true
+    signInAfterRegistration: true
+    emailVerificationPendingRoute: '/verification-pending'
 
   isStringEmail: (email) ->
     emailPattern = /^([\w.-]+)@([\w.-]+)\.([a-zA-Z.]{2,6})$/i

--- a/client/t9n/arabic.coffee
+++ b/client/t9n/arabic.coffee
@@ -25,6 +25,8 @@ ar =
   configure: "تعديل"
   with: "مع"
   createAccount: "افتح حساب جديد"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "و"
   "Match failed":  "المطابقة فشلت"
   "User not found":  "اسم المستخدم غير موجود"

--- a/client/t9n/english.coffee
+++ b/client/t9n/english.coffee
@@ -25,6 +25,8 @@ en =
   configure: "Configure"
   with: "with"
   createAccount: "Create an Account"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "and"
   "Match failed":  "Match failed"
   "User not found":  "User not found"

--- a/client/t9n/french.coffee
+++ b/client/t9n/french.coffee
@@ -25,6 +25,8 @@ fr =
   configure: "Configurer"
   with: "avec"
   createAccount: "Créer un compte"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "et"
 
   error:

--- a/client/t9n/german.coffee
+++ b/client/t9n/german.coffee
@@ -25,6 +25,8 @@ de =
   configure: "Konfigurieren"
   with: "mit"
   createAccount: "Konto erzeugen"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "und"
 
   error:

--- a/client/t9n/italian.coffee
+++ b/client/t9n/italian.coffee
@@ -25,6 +25,8 @@ it =
   configure: "Configura"
   with: "con"
   createAccount: "Crea un Account"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "e"
   "Match failed":  "Riscontro fallito"
   "User not found":  "Utente non trovato"

--- a/client/t9n/polish.coffee
+++ b/client/t9n/polish.coffee
@@ -25,6 +25,8 @@ pl =
   configure: "Konfiguruj"
   with: "z"
   createAccount: "Utwórz konto"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "i"
 
   error:

--- a/client/t9n/portuguese.coffee
+++ b/client/t9n/portuguese.coffee
@@ -25,6 +25,8 @@ pt =
   configure: "Configurar"
   with: "com"
   createAccount: "Criar Conta"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "e"
   "Match failed":  "Usuário ou senha não encontrado"
   "User not found":  "Usuário não encontrado"

--- a/client/t9n/russian.coffee
+++ b/client/t9n/russian.coffee
@@ -25,6 +25,8 @@ ru =
   configure: "Конфигурировать"
   with: "с"
   createAccount: "Создать аккаунт"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "и"
   "Match failed":  "Не совпадают"
   "User not found":  "Пользователь не найден"

--- a/client/t9n/slovene.coffee
+++ b/client/t9n/slovene.coffee
@@ -25,6 +25,8 @@ sl =
   configure: "Nastavi"
   with: "z"
   createAccount: "Nova registracija"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "in"
   "Match failed":  "Prijava neuspešna"
   "User not found":  "Uporabnik ne obstaja"

--- a/client/t9n/spanish.coffee
+++ b/client/t9n/spanish.coffee
@@ -24,6 +24,8 @@ es =
   configure: "Disposición"
   with: "con"
   createAccount: "Crear cuenta"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "y"
 
   error:

--- a/client/t9n/swedish.coffee
+++ b/client/t9n/swedish.coffee
@@ -25,6 +25,8 @@ sv =
   configure: "Konfigurera"
   with: "med"
   createAccount: "Skapa ett konto"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "och"
   "Match failed":  "Matchning misslyckades"
   "User not found":  "Användaren hittades inte"

--- a/client/views/signUp/signUp.coffee
+++ b/client/views/signUp/signUp.coffee
@@ -147,6 +147,7 @@ AccountsEntry.entrySignUpEvents = {
             'USERNAME_AND_EMAIL',
             'EMAIL_ONLY'], AccountsEntry.settings.passwordSignupFields)
           userCredential = if isEmailSignUp then email else username
+          if AccountsEntry.settings.signInAfterRegistration is true
           Meteor.loginWithPassword userCredential, password, (error) ->
             if error
               console.log error
@@ -156,6 +157,9 @@ AccountsEntry.entrySignUpEvents = {
               Session.set 'fromWhere', undefined
             else
               Router.go AccountsEntry.settings.dashboardRoute
+      else
+            if AccountsEntry.settings.emailVerificationPendingRoute
+              Router.go AccountsEntry.settings.emailVerificationPendingRoute
       else
         console.log err
         Session.set 'entryError', t9n("error.signupCodeIncorrect")

--- a/client/views/signUp/signUp.coffee
+++ b/client/views/signUp/signUp.coffee
@@ -157,7 +157,7 @@ AccountsEntry.entrySignUpEvents = {
               Session.set 'fromWhere', undefined
             else
               Router.go AccountsEntry.settings.dashboardRoute
-      else
+          else
             if AccountsEntry.settings.emailVerificationPendingRoute
               Router.go AccountsEntry.settings.emailVerificationPendingRoute
       else

--- a/client/views/verificationPending/verificationPending.coffee
+++ b/client/views/verificationPending/verificationPending.coffee
@@ -1,0 +1,6 @@
+Template.entryVerificationPending.helpers
+  error: -> t9n(Session.get('entryError'))
+
+  logo: ->
+    AccountsEntry.settings.logo
+

--- a/client/views/verificationPending/verificationPending.html
+++ b/client/views/verificationPending/verificationPending.html
@@ -1,0 +1,26 @@
+<template name='entryVerificationPending'>
+  <div class="{{containerCSSClass}}">
+    <div class="{{rowCSSClass}}">
+      {{#if logo}}
+        <div class="entry-logo">
+            <a href="/"><img src="{{logo}}" alt="logo"></a>
+        </div>
+      {{/if}}
+      <div class="entry col-md-4 col-md-offset-4">
+        {{#if error}}
+          <div class='alert alert-danger'>{{error}}</div>
+        {{/if}}
+        <div class="panel panel-info">
+          <div class="panel-heading">
+            <h3 class="panel-title">{{t9n 'verificationPending'}}</h3>
+          </div>
+          <div class="panel-body">
+            {{t9n 'verificationPendingDetails'}}
+          </div>
+          
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+

--- a/package.js
+++ b/package.js
@@ -46,6 +46,8 @@ Package.onUse(function(api) {
     'client/views/accountButtons/_wrapLinks.html',
     'client/views/accountButtons/signedIn.html',
     'client/views/accountButtons/accountButtons.coffee',
+    'client/views/verificationPending/verificationPending.html',
+    'client/views/verificationPending/verificationPending.coffee',
     'client/t9n/english.coffee',
     'client/t9n/french.coffee',
     'client/t9n/german.coffee',

--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -76,8 +76,9 @@ Router.map ->
 
   @route 'entryVerificationPending',
     path: '/verification-pending'
-    onBeforeAction: (pause)->
+    onBeforeAction: ->
       Session.set('entryError', undefined)
+      @next()
 
   @route 'entryResetPassword',
     path: 'reset-password/:resetToken'

--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -74,6 +74,11 @@ Router.map ->
           Router.go AccountsEntry.settings.homeRoute
       @next()
 
+  @route 'entryVerificationPending',
+    path: '/verification-pending'
+    onBeforeAction: (pause)->
+      Session.set('entryError', undefined)
+
   @route 'entryResetPassword',
     path: 'reset-password/:resetToken'
     onBeforeAction: ->


### PR DESCRIPTION
NOTE: Has a dependency on pull request #345 . Merge #345 first.

This is a change to allow prevention of the user being automatically signed-in upon registration; they need an explicit sign-in (e.g. once their email has been verified).

*NOTE 2*
There will be a merge conflict if/when this is merged after #345 (I wasn't sure how best to separate these). All four modified lines of entry.coffee should be included, to ensure it doesn't break people's existing installations:

(from line 12)
```coffee
    fluidLayout: false
    useContainer: true
    signInAfterRegistration: true
    emailVerificationPendingRoute: '/verification-pending'
```

