### PR TITLE
Add attributes to input fields for mobile devices

### DIFF
--- a/client/views/signIn/signIn.html
+++ b/client/views/signIn/signIn.html
@@ -28,7 +28,7 @@
         {{#if passwordLoginService}}
           <form class="entry-form" id='signIn'>
             <div class="form-group">
-              <input autofocus name="email" type="{{emailInputType}}" class="form-control" value='{{email}}' placeholder="{{emailPlaceholder}}">
+              <input autofocus name="email" type="{{emailInputType}}" class="form-control" value='{{email}}' placeholder="{{emailPlaceholder}}" autocapitalize="none" autocomplete="off" autocorrect="off">
             </div>
             <div class="form-group">
               <input name="password" type="password" class="form-control" value='{{password}}' placeholder="{{t9n 'password'}}">

--- a/client/views/signUp/signUp.html
+++ b/client/views/signUp/signUp.html
@@ -32,7 +32,7 @@
             {{#if showUsername}}
               <div class="form-group">
                 <label>{{t9n "username"}}</label>
-                <input autofocus name="username" type="string" class="form-control" value=''>
+                <input autofocus name="username" type="string" class="form-control" value=''  autocapitalize="none" autocomplete="off" autocorrect="off">
               </div>
             {{/if}}
 
@@ -40,9 +40,9 @@
               <div class="form-group">
                 <label>{{t9n "emailAddress"}}</label>
                 {{#if showUsername}}
-                  <input type="email" class="form-control" value='{{emailAddress}}'>
+                  <input type="email" class="form-control" value='{{emailAddress}}'  autocapitalize="none" autocomplete="off" autocorrect="off">
                 {{else}}
-                  <input autofocus type="email" class="form-control" value='{{emailAddress}}'>
+                  <input autofocus type="email" class="form-control" value='{{emailAddress}}'  autocapitalize="none" autocomplete="off" autocorrect="off" >
                 {{/if}}
               </div>
             {{/if}}
@@ -55,7 +55,7 @@
             {{#if showSignupCode}}
               <div class="form-group">
                 <label>{{t9n "signupCode"}}</label>
-                <input name="signupCode" type="string" class="form-control" value=''>
+                <input name="signupCode" type="string" class="form-control" value=''  autocapitalize="none" autocomplete="off" autocorrect="off" >
               </div>
             {{/if}}
 


### PR DESCRIPTION
Add attributes to input fields to prevent autocapitalisation, autocomplete and autocorrect (particularly on mobile devices).