### PR TITLE
Feature/wait for email verification2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You will get routes and the necessary templates for:
 /sign-out
 /sign-up
 /forgot-password
+/verification-pending
 ```
 
 You can then either add links to those directly, or use the `{{ special }}` helper we provide to give you the apppropriate links for signed-in/signed-out users.  The `{{ special }}` helper will display a sign-out link and the user's email address when they are signed-in.
@@ -103,6 +104,11 @@ Since this is a young package, we are maintaining compatibility with accounts-ui
         type: "text",                            // The type of field you want
         required: true                           // Adds html 5 required property if true
        }]
+       fluidLayout: false               // Set to true to use bootstrap3 container-fluid and row-fluid classes.
+       useContainer: true               // Set to false to use an unstyled "accounts-entry-container" class instead of a bootstrap3 "container" or "container-fluid" class. 
+       signInAfterRegistration: true     // Set to false to avoid prevent users being automatically signed up upon sign-up e.g. to wait until their email has been verified. 
+       emailVerificationPendingRoute: '/verification-pending' // The route to which users should be directed after sign-up. Only relevant if signInAfterRegistration is false.
+
     });
   });
 ```

--- a/client/entry.coffee
+++ b/client/entry.coffee
@@ -11,6 +11,8 @@ AccountsEntry =
     showOtherLoginServices: true
     fluidLayout: false
     useContainer: true
+    signInAfterRegistration: true
+    emailVerificationPendingRoute: '/verification-pending'
 
   isStringEmail: (email) ->
     emailPattern = /^([\w.-]+)@([\w.-]+)\.([a-zA-Z.]{2,6})$/i

--- a/client/t9n/arabic.coffee
+++ b/client/t9n/arabic.coffee
@@ -25,6 +25,8 @@ ar =
   configure: "تعديل"
   with: "مع"
   createAccount: "افتح حساب جديد"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "و"
   "Match failed":  "المطابقة فشلت"
   "User not found":  "اسم المستخدم غير موجود"

--- a/client/t9n/english.coffee
+++ b/client/t9n/english.coffee
@@ -25,6 +25,8 @@ en =
   configure: "Configure"
   with: "with"
   createAccount: "Create an Account"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "and"
   "Match failed":  "Match failed"
   "User not found":  "User not found"

--- a/client/t9n/french.coffee
+++ b/client/t9n/french.coffee
@@ -25,6 +25,8 @@ fr =
   configure: "Configurer"
   with: "avec"
   createAccount: "Créer un compte"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "et"
 
   error:

--- a/client/t9n/german.coffee
+++ b/client/t9n/german.coffee
@@ -25,6 +25,8 @@ de =
   configure: "Konfigurieren"
   with: "mit"
   createAccount: "Konto erzeugen"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "und"
 
   error:

--- a/client/t9n/italian.coffee
+++ b/client/t9n/italian.coffee
@@ -25,6 +25,8 @@ it =
   configure: "Configura"
   with: "con"
   createAccount: "Crea un Account"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "e"
   "Match failed":  "Riscontro fallito"
   "User not found":  "Utente non trovato"

--- a/client/t9n/polish.coffee
+++ b/client/t9n/polish.coffee
@@ -25,6 +25,8 @@ pl =
   configure: "Konfiguruj"
   with: "z"
   createAccount: "Utwórz konto"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "i"
 
   error:

--- a/client/t9n/portuguese.coffee
+++ b/client/t9n/portuguese.coffee
@@ -25,6 +25,8 @@ pt =
   configure: "Configurar"
   with: "com"
   createAccount: "Criar Conta"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "e"
   "Match failed":  "Usuário ou senha não encontrado"
   "User not found":  "Usuário não encontrado"

--- a/client/t9n/russian.coffee
+++ b/client/t9n/russian.coffee
@@ -25,6 +25,8 @@ ru =
   configure: "Конфигурировать"
   with: "с"
   createAccount: "Создать аккаунт"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "и"
   "Match failed":  "Не совпадают"
   "User not found":  "Пользователь не найден"

--- a/client/t9n/slovene.coffee
+++ b/client/t9n/slovene.coffee
@@ -25,6 +25,8 @@ sl =
   configure: "Nastavi"
   with: "z"
   createAccount: "Nova registracija"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "in"
   "Match failed":  "Prijava neuspešna"
   "User not found":  "Uporabnik ne obstaja"

--- a/client/t9n/spanish.coffee
+++ b/client/t9n/spanish.coffee
@@ -24,6 +24,8 @@ es =
   configure: "Disposición"
   with: "con"
   createAccount: "Crear cuenta"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "y"
 
   error:

--- a/client/t9n/swedish.coffee
+++ b/client/t9n/swedish.coffee
@@ -25,6 +25,8 @@ sv =
   configure: "Konfigurera"
   with: "med"
   createAccount: "Skapa ett konto"
+  verificationPending: "Confirm your email address"
+  verificationPendingDetails: "A confirmation email has been sent to the email address you provided. Click on the confirmation link in the email to activate your account."
   and: "och"
   "Match failed":  "Matchning misslyckades"
   "User not found":  "Användaren hittades inte"

--- a/client/views/signUp/signUp.coffee
+++ b/client/views/signUp/signUp.coffee
@@ -147,6 +147,7 @@ AccountsEntry.entrySignUpEvents = {
             'USERNAME_AND_EMAIL',
             'EMAIL_ONLY'], AccountsEntry.settings.passwordSignupFields)
           userCredential = if isEmailSignUp then email else username
+          if AccountsEntry.settings.signInAfterRegistration is true
           Meteor.loginWithPassword userCredential, password, (error) ->
             if error
               console.log error
@@ -156,6 +157,9 @@ AccountsEntry.entrySignUpEvents = {
               Session.set 'fromWhere', undefined
             else
               Router.go AccountsEntry.settings.dashboardRoute
+      else
+            if AccountsEntry.settings.emailVerificationPendingRoute
+              Router.go AccountsEntry.settings.emailVerificationPendingRoute
       else
         console.log err
         Session.set 'entryError', t9n("error.signupCodeIncorrect")

--- a/client/views/signUp/signUp.coffee
+++ b/client/views/signUp/signUp.coffee
@@ -146,17 +146,20 @@ AccountsEntry.entrySignUpEvents = {
           isEmailSignUp = _.contains([
             'USERNAME_AND_EMAIL',
             'EMAIL_ONLY'], AccountsEntry.settings.passwordSignupFields)
-          userCredential = if isEmailSignUp then email else username
+          if isEmailSignUp 
+            userCredential = email 
+          else 
+            userCredential = username
           if AccountsEntry.settings.signInAfterRegistration is true
-          Meteor.loginWithPassword userCredential, password, (error) ->
-            if error
-              console.log error
-              T9NHelper.accountsError error
-            else if Session.get 'fromWhere'
-              Router.go Session.get('fromWhere')
-              Session.set 'fromWhere', undefined
-            else
-              Router.go AccountsEntry.settings.dashboardRoute
+            Meteor.loginWithPassword userCredential, password, (error) ->
+              if error
+                console.log error
+                T9NHelper.accountsError error
+              else if Session.get 'fromWhere'
+                Router.go Session.get('fromWhere')
+                Session.set 'fromWhere', undefined
+              else
+                Router.go AccountsEntry.settings.dashboardRoute
           else
             if AccountsEntry.settings.emailVerificationPendingRoute
               Router.go AccountsEntry.settings.emailVerificationPendingRoute

--- a/client/views/signUp/signUp.coffee
+++ b/client/views/signUp/signUp.coffee
@@ -157,7 +157,7 @@ AccountsEntry.entrySignUpEvents = {
               Session.set 'fromWhere', undefined
             else
               Router.go AccountsEntry.settings.dashboardRoute
-      else
+          else
             if AccountsEntry.settings.emailVerificationPendingRoute
               Router.go AccountsEntry.settings.emailVerificationPendingRoute
       else

--- a/client/views/verificationPending/verificationPending.coffee
+++ b/client/views/verificationPending/verificationPending.coffee
@@ -1,0 +1,6 @@
+Template.entryVerificationPending.helpers
+  error: -> t9n(Session.get('entryError'))
+
+  logo: ->
+    AccountsEntry.settings.logo
+

--- a/client/views/verificationPending/verificationPending.html
+++ b/client/views/verificationPending/verificationPending.html
@@ -1,0 +1,26 @@
+<template name='entryVerificationPending'>
+  <div class="{{containerCSSClass}}">
+    <div class="{{rowCSSClass}}">
+      {{#if logo}}
+        <div class="entry-logo">
+            <a href="/"><img src="{{logo}}" alt="logo"></a>
+        </div>
+      {{/if}}
+      <div class="entry col-md-4 col-md-offset-4">
+        {{#if error}}
+          <div class='alert alert-danger'>{{error}}</div>
+        {{/if}}
+        <div class="panel panel-info">
+          <div class="panel-heading">
+            <h3 class="panel-title">{{t9n 'verificationPending'}}</h3>
+          </div>
+          <div class="panel-body">
+            {{t9n 'verificationPendingDetails'}}
+          </div>
+          
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+

--- a/package.js
+++ b/package.js
@@ -46,6 +46,8 @@ Package.onUse(function(api) {
     'client/views/accountButtons/_wrapLinks.html',
     'client/views/accountButtons/signedIn.html',
     'client/views/accountButtons/accountButtons.coffee',
+    'client/views/verificationPending/verificationPending.html',
+    'client/views/verificationPending/verificationPending.coffee',
     'client/t9n/english.coffee',
     'client/t9n/french.coffee',
     'client/t9n/german.coffee',

--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -75,6 +75,11 @@ Router.map ->
         Meteor.logout () ->
           Router.go AccountsEntry.settings.homeRoute
 
+  @route 'entryVerificationPending',
+    path: '/verification-pending'
+    onBeforeAction: (pause)->
+      Session.set('entryError', undefined)
+
   @route 'entryResetPassword',
     path: 'reset-password/:resetToken'
     onBeforeAction: ->

--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -77,8 +77,9 @@ Router.map ->
 
   @route 'entryVerificationPending',
     path: '/verification-pending'
-    onBeforeAction: (pause)->
+    onBeforeAction: ->
       Session.set('entryError', undefined)
+      @next()
 
   @route 'entryResetPassword',
     path: 'reset-password/:resetToken'


### PR DESCRIPTION
This is a change to allow prevention of the user being automatically signed-in upon registration; they need an explicit sign-in (e.g. once their email has been verified).

new settings (with defaults that won't break existing installs):
```coffee
    signInAfterRegistration: true
    emailVerificationPendingRoute: '/verification-pending'
```

Note: this is a resubmission of #346, updated for easy merging. Also, the README has been updated to document the bootstrap3 fluid layout settings.
/cc @fix 