### PR TITLE
Removed ids on forms, switched to class selectors and scoped all jquery selects to their own template

### DIFF
--- a/client/views/enrollAccount/enrollAccount.coffee
+++ b/client/views/enrollAccount/enrollAccount.coffee
@@ -6,9 +6,9 @@ Template.entryEnrollAccount.helpers
 
 Template.entryEnrollAccount.events
 
-  'submit #setPassword': (event) ->
+  'submit form.set-password': (event, template) ->
     event.preventDefault()
-    password = $('input[type="password"]').val()
+    password = template.$('input[type="password"]').val()
 
     passwordErrors = do (password)->
       errMsg = []

--- a/client/views/enrollAccount/enrollAccount.html
+++ b/client/views/enrollAccount/enrollAccount.html
@@ -11,7 +11,7 @@
           <div class='alert alert-danger'>{{error}}</div>
         {{/if}}
         <h3>{{t9n "choosePassword"}}</h3>
-        <form id='setPassword'>
+        <form class='set-password'>
           <div class="form-group">
             <input type="password" name="new-password" class="form-control" value=''>
           </div>

--- a/client/views/forgotPassword/forgotPassword.coffee
+++ b/client/views/forgotPassword/forgotPassword.coffee
@@ -5,9 +5,9 @@ Template.entryForgotPassword.helpers
     AccountsEntry.settings.logo
 
 Template.entryForgotPassword.events
-  'submit #forgotPassword': (event) ->
+  'submit form.forgot-password': (event, template) ->
     event.preventDefault()
-    Session.set('email', $('input[name="forgottenEmail"]').val())
+    Session.set('email', template.$('input[name="forgottenEmail"]').val())
 
     if Session.get('email').length is 0
       Session.set('entryError', 'Email is required')

--- a/client/views/forgotPassword/forgotPassword.html
+++ b/client/views/forgotPassword/forgotPassword.html
@@ -11,7 +11,7 @@
           <div class='alert alert-danger'>{{error}}</div>
         {{/if}}
         <h3>{{t9n 'forgotPassword'}}</h3>
-        <form id='forgotPassword'>
+        <form class='forgot-password'>
           <div class="form-group">
             <input type="email" name="forgottenEmail" class="form-control" placeholder="{{t9n 'emailAddress'}}" value=''>
           </div>

--- a/client/views/resetPassword/resetPassword.coffee
+++ b/client/views/resetPassword/resetPassword.coffee
@@ -6,9 +6,9 @@ Template.entryResetPassword.helpers
 
 Template.entryResetPassword.events
 
-  'submit #resetPassword': (event) ->
+  'submit form.reset-password': (event, template) ->
     event.preventDefault()
-    password = $('input[type="password"]').val()
+    password = template.$('input[type="password"]').val()
 
     passwordErrors = do (password)->
       errMsg = []

--- a/client/views/resetPassword/resetPassword.html
+++ b/client/views/resetPassword/resetPassword.html
@@ -11,7 +11,7 @@
           <div class='alert alert-danger'>{{error}}</div>
         {{/if}}
         <h3>{{t9n "resetYourPassword"}}</h3>
-        <form id='resetPassword'>
+        <form class='reset-password'>
           <div class="form-group">
             <input type="password" name="new-password" class="form-control" value=''>
           </div>

--- a/client/views/signIn/signIn.coffee
+++ b/client/views/signIn/signIn.coffee
@@ -27,16 +27,16 @@ AccountsEntry.entrySignInHelpers = {
 }
 
 AccountsEntry.entrySignInEvents = {
-  'submit #signIn': (event) ->
+  'submit form.entry-form.sign-in': (event, template) ->
     event.preventDefault()
 
-    email = $('input[name="email"]').val()
+    email = template.$('input[name="email"]').val()
     if (AccountsEntry.isStringEmail(email) and AccountsEntry.settings.emailToLower) or
      (not AccountsEntry.isStringEmail(email) and AccountsEntry.settings.usernameToLower)
       email = email.toLowerCase()
 
     Session.set('email', email)
-    Session.set('password', $('input[name="password"]').val())
+    Session.set('password', template.$('input[name="password"]').val())
     Session.set 'talkingToServer', true
 
     Meteor.loginWithPassword(Session.get('email'), Session.get('password'), (error)->

--- a/client/views/signIn/signIn.html
+++ b/client/views/signIn/signIn.html
@@ -26,7 +26,7 @@
           </div>
         {{/unless}}
         {{#if passwordLoginService}}
-          <form class="entry-form" id='signIn'>
+          <form class="entry-form sign-in">
             <div class="form-group">
               <input autofocus name="email" type="{{emailInputType}}" class="form-control" value='{{email}}' placeholder="{{emailPlaceholder}}" autocapitalize="none" autocomplete="off" autocorrect="off">
             </div>

--- a/client/views/signUp/signUp.coffee
+++ b/client/views/signUp/signUp.coffee
@@ -49,7 +49,7 @@ AccountsEntry.entrySignUpHelpers = {
 }
 
 AccountsEntry.entrySignUpEvents = {
-  'submit #signUp': (event, t) ->
+  'submit form.sign-up': (event, t) ->
     event.preventDefault()
 
     username =

--- a/client/views/signUp/signUp.html
+++ b/client/views/signUp/signUp.html
@@ -17,7 +17,7 @@
             {{#if passwordLoginService}}
               <div class="email-option">
                 <strong class="line-thru">{{t9n "OR"}}</strong>
-                <a data-toggle="collapse" href="#signUp">
+                <a data-toggle="collapse" href="form.sign-up">
                   {{t9n "signUpWithYourEmailAddress"}}
                 </a>
               </div>
@@ -28,7 +28,7 @@
         {{/if}}
         {{> entryError}}
         {{#if passwordLoginService}}
-          <form class="entry-form {{signupClass}}" id='signUp'>
+          <form class="entry-form {{signupClass}} sign-up">
             {{#if showUsername}}
               <div class="form-group">
                 <label>{{t9n "username"}}</label>


### PR DESCRIPTION
I'm trying to use this module for some off-label purposes (using the templates inside bootstrap modal, as well as the auth route pages) . As part of that, I needed to clean up some stuff so that more than one instance of the sign in form can exist in the DOM at a time (e.g. a hidden version which could be shown as a bootstrap modal). 

Here's the changes that I've made. Hopefully it's not too controversial and you can accept my PR:

1. Forms are referenced by ID (#signIn etc). Since we shouldn't assume anything about the enclosing project's layouts and other html, and since IDs must be unique, it's better to reference by class rather than just occupy a rather generic named id. So I removed the IDs and switched the selectors to classes instead.

2. There are some instances where template events are getting the value of an input using a very general selector and with global scope, e.g.

 ```javascript
password = $('input[type="password"]').val()
```
So if any other <input type="password"> exists in the layout for example, there will be problems. This would be much better scoped to the template, like so:

```javascript
password = template.$('input[type="password"]').val()
```

Hope this makes sense.