### PR TITLE
Fix and update enrollAccount

### DIFF
--- a/client/views/enrollAccount/enrollAccount.html
+++ b/client/views/enrollAccount/enrollAccount.html
@@ -1,6 +1,6 @@
 <template name='entryEnrollAccount'>
-  <div class="container">
-    <div class="row">
+  <div class="{{containerCSSClass}}">
+    <div class="{{rowCSSClass}}">
       {{#if logo}}
         <div class="entry-logo">
             <a href="/"><img src="{{logo}}" alt="logo"></a>
@@ -18,7 +18,10 @@
           <button type="submit" class="btn btn-default">{{t9n "setPassword"}}</button>
         </form>
         {{#if showSignupCode}}
-          <p class="entry-signup-cta">{{t9n 'dontHaveAnAccount'}} <a href="/sign-up">{{t9n 'signUp'}}</a></p>
+          <p class="entry-signup-cta">{{t9n 'dontHaveAnAccount'}} <a href="{{pathFor 'entrySignUp'}}">{{t9n 'signUp'}}</a></p>
+        {{/if}}
+        {{#if talkingToServer}}
+          {{> spinner}}
         {{/if}}
       </div>
     </div>

--- a/shared/router.coffee
+++ b/shared/router.coffee
@@ -93,6 +93,7 @@ Router.map ->
     onBeforeAction: ->
       Session.set('entryError', undefined)
       Session.set('resetToken', @params.resetToken)
+      @next()
 
 # Get all the accounts-entry routes one time
 exclusions = []


### PR DESCRIPTION
This actually broke when Iron Router started requiring the `this.next()` call. I also updated the template to match changes in similar templates.