### PR TITLE
Fixed: Having the login type set to USERNAME_ONLY would hide the login button

### DIFF
--- a/client/views/signIn/signIn.html
+++ b/client/views/signIn/signIn.html
@@ -33,10 +33,10 @@
             <div class="form-group">
               <input name="password" type="password" class="form-control" value='{{password}}' placeholder="{{t9n 'password'}}">
             </div>
-            {{#unless isUsernameOnly}}
-              <p><a href="{{pathFor 'entryForgotPassword'}}">{{t9n "forgotPassword"}}</a></p>
+              {{#unless isUsernameOnly}}
+                <p><a href="{{pathFor 'entryForgotPassword'}}">{{t9n "forgotPassword"}}</a></p>
+              {{/unless}}
               <button type="submit" class="submit btn btn-block btn-default">{{t9n "signIn"}}</button>
-            {{/unless}}
           </form>
         {{/if}}
         {{#if showCreateAccountLink}}


### PR DESCRIPTION
Just a misplaced closing bracket for an {{unless}} block in a handlebars helper.